### PR TITLE
Fix for #4  methods return undefined.

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -12,10 +12,10 @@ public class CapacitorAppTrackingTransparency: CAPPlugin {
         if #available(iOS 14.0, *) {
             let status: ATTrackingManager.AuthorizationStatus = ATTrackingManager.trackingAuthorizationStatus
             call.success([
-                "status": status.rawValue == 0 ? "unrequested" : status.rawValue == 1 ? "restricted" : status.rawValue == 2 ? "denied" : status.rawValue == 3 ? "authorized" : "",
+                "value": status.rawValue == 0 ? "unrequested" : status.rawValue == 1 ? "restricted" : status.rawValue == 2 ? "denied" : status.rawValue == 3 ? "authorized" : "",
             ])
         } else {
-            call.success(["status": "authorized"])
+            call.success(["value": "authorized"])
         }
     }
 
@@ -24,11 +24,11 @@ public class CapacitorAppTrackingTransparency: CAPPlugin {
             ATTrackingManager.requestTrackingAuthorization { res in
                 let status = res
                 call.success([
-                    "status": status.rawValue == 0 ? "unrequested" : status.rawValue == 1 ? "restricted" : status.rawValue == 2 ? "denied" : status.rawValue == 3 ? "authorized" : "",
+                    "value": status.rawValue == 0 ? "unrequested" : status.rawValue == 1 ? "restricted" : status.rawValue == 2 ? "denied" : status.rawValue == 3 ? "authorized" : "",
                 ])
             }
         } else {
-            call.success(["status": "authorized"])
+            call.success(["value": "authorized"])
         }
     }
 }


### PR DESCRIPTION
In plugin.ts all methods are wrapped with wrapMethod(), which expects a 'value' property on the returned value. The swift methods are returning a 'status' property so in the end the result was undefined.

I've created a branch from an earlier point, because I need a v2 compatible plugin. Would be great if you could release a 0.1.5! 👍🏻  